### PR TITLE
Added "none" to FLAGS signature in Extended Basis.

### DIFF
--- a/com/ssh/extended-basis/unstable/public/concept/flags.sig
+++ b/com/ssh/extended-basis/unstable/public/concept/flags.sig
@@ -36,6 +36,9 @@ signature FLAGS = sig
    (** This is always equivalent to {(toWord, fromWord)}. *)
 
    (** == Constants == *)
+   
+   val none: flags
+   (** The empty set. *)
 
    val all : flags
    (** The union of all flags. *)


### PR DESCRIPTION
The `FLAGS` signature in the Extended Basis includes a value `all` for the union of all flags, but doesn't have a `none` value. This appears to be an error of omission, because the `MkWordFlags` functor -- which I think is the only implementation of `FLAGS` in the Extended Basis -- does provide `none`!

The lack of a `none` value makes using opaque/abstract flag implementations awkward. To create an empty flag you'd have to pick an existing flag `f` and apply `clear (all, f)`. Alternatively you could use `fromWord 0w0`, but this makes assumptions about the internal representation of the flags. Either way, it's not exactly ideal.

Adding to the signature could theoretically break someone's code if they wrote their own abstract flags structure, but:
- In practice the `MkWordFlags` implementation is probably what everyone uses
- fixing a broken implementation should be trivial
- the Extended Basis appears to have never gotten a "stable" version

So I think this is a fairly harmless change.
